### PR TITLE
Remove redundant json and prevent key error

### DIFF
--- a/repair_agent/autogpt/agents/agent.py
+++ b/repair_agent/autogpt/agents/agent.py
@@ -184,6 +184,11 @@ class Agent(BaseAgent):
             patf.write(llm_response.content)
         assistant_reply_dict = extract_dict_from_response(llm_response.content)
 
+        if not isinstance(assistant_reply_dict, dict):
+            raise SyntaxError(
+                "assistant_reply_dict is not dict"
+            )
+
         if "command" not in assistant_reply_dict:
             assistant_reply_dict["command"] = {"name": "missing_command", "args":{}}
         command_dict = assistant_reply_dict["command"]

--- a/repair_agent/autogpt/agents/base.py
+++ b/repair_agent/autogpt/agents/base.py
@@ -338,9 +338,9 @@ please use the indicated format and produce a list, like this:
             commands_interface = json.load(cif)
 
         command_dict = command_dict.get("command", {"name": "", "args": {}})
-        if command_dict["name"] in list(commands_interface.keys()):
+        if command_dict.get("name", None) in list(commands_interface.keys()):
             ref_args = commands_interface[command_dict["name"]]
-            if isinstance(command_dict["args"], dict):
+            if isinstance(command_dict.get("args", None), dict):
                 command_args = list(command_dict["args"].keys())
                 if set(command_args) == set(ref_args):
                     return True

--- a/repair_agent/autogpt/json_utils/utilities.py
+++ b/repair_agent/autogpt/json_utils/utilities.py
@@ -20,6 +20,8 @@ def extract_dict_from_response(response_content: str) -> dict[str, Any]:
         end_triple_quote = response_content[3:].find("```")
         if end_triple_quote != -1:
             response_content = response_content[:end_triple_quote+3]
+            if response_content.startswith('json'):
+                response_content = response_content[4:]
             response_content = "\n".join(response_content.split("\n")[1:])
             
         """if response_content.startswith("```") and response_content.endswith("```"):


### PR DESCRIPTION
Remove redundant json and prevent key error, as the json response could be wrapped with \`\`\` json and \`\`\`, and the content of the json could have wrong structure.